### PR TITLE
TEL-1866: massively simplify templating for build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 * [Initialising a repository](#Initialising-a-repository)
 * [Linking an existing repository](#Linking-an-existing-repository)
 * [Updating the repository](#Updating-the-repository)
-* [Setting Docker Build Parameters](#Setting-Docker-Build-Parameters)
+* [Setting Docker Parameters](#Setting-Docker-Parameters)
 * [References](#References)
 * [License](#License)
 
@@ -101,140 +101,98 @@ cruft update --skip-apply-ask
 cruft diff | git apply
 ```
 
-## Setting Docker Build Parameters
-You can manage the Docker build commands using two variables `docker_build_info_default` and `docker_build_info_additional`.
+## Setting Docker Parameters
+You can manage the Docker build commands using two variables `docker_include_default_build` and `docker_builds`.
 The examples below demonstrate the different outcomes based on the contents of the dictionary values specified.
 
-**Note:** The Json blocks below are only snippets of the full Json required for simplicity
+**Note:** Jinja2 will accept `true`, `True`, `yes` and `yes` as boolean `true`. Any other value will result in `false`
 
-### Default build with no build arguments or tag suffixes
+### Including the default build with no options
 
 #### Input (.cruft.json)
 ```json
 {
-  "template": "https://github.com/hmrc/telemetry-docker-resources",
-  "context": {
-    "cookiecutter": {
-      "docker_build_info_additional": {},
-      "docker_build_info_default": {}
-    }
+  "cookiecutter": {
+    "additional_tool_versions": {},
+    "aws_account_id": "634456480543",
+    "aws_region": "eu-west-2",
+    "custom_makefile_name": "",
+    "docker_build_options_additional": {
+      "-heartbeat": "--platform 'linux/amd64' --build-arg MODE_HEARTBEAT=1",
+      "-webops-heartbeat": "--build-arg MODE_HEARTBEAT=1 --build-arg IS_WEBOPS_ENV=1"
+    },
+    "docker_image_name": "telemetry-elastic-loadtest",
+    "docker_image_name_formatted": "telemetry-elastic-loadtest",
+    "docker_include_default_build": true,
+    "_template": "https://github.com/hmrc/telemetry-docker-resources"
   }
 }
 ```
 
 #### Output (bin/docker-tools.sh)
 ```shell
-  docker build --tag "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${REPO_NAME}:${VERSION}" .
+docker build --tag "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-elastic-loadtest:${VERSION}" .
+docker build --tag "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-elastic-loadtest:${VERSION}-heartbeat" --platform 'linux/amd64' --build-arg MODE_HEARTBEAT=1 .
+docker build --tag "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-elastic-loadtest:${VERSION}-webops-heartbeat" --build-arg MODE_HEARTBEAT=1 --build-arg IS_WEBOPS_ENV=1 .
 ```
 
-### Default build only with build arguments
+### Including the default build with options
 
 #### Input (.cruft.json)
 ```json
 {
-  "template": "https://github.com/hmrc/telemetry-docker-resources",
-  "context": {
-    "cookiecutter": {
-      "docker_build_info_additional": {},
-      "docker_build_info_default": {
-        "default": {
-          "build_args": [
-            "MODE_HEARTBEAT=1"
-          ],
-          "platform": [
-            "'linux/amd64'"
-          ]
-        }
-      }
-    }
+  "cookiecutter": {
+    "additional_tool_versions": {},
+    "aws_account_id": "634456480543",
+    "aws_region": "eu-west-2",
+    "custom_makefile_name": "",
+    "docker_build_options_additional": {
+      "-heartbeat": "--platform 'linux/amd64' --build-arg MODE_HEARTBEAT=1",
+      "-webops-heartbeat": "--build-arg MODE_HEARTBEAT=1 --build-arg IS_WEBOPS_ENV=1"
+    },
+    "docker_build_options_default": "--platform 'linux/amd64'",
+    "docker_image_name": "telemetry-elastic-loadtest",
+    "docker_image_name_formatted": "telemetry-elastic-loadtest",
+    "docker_include_default_build": true,
+    "_template": "https://github.com/hmrc/telemetry-docker-resources"
   }
 }
 ```
 
 #### Output (bin/docker-tools.sh)
 ```shell
-  docker build --tag "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${REPO_NAME}:${VERSION}" --build-arg MODE_HEARTBEAT=1 --platform 'linux/amd64' .
+docker build --tag "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-elastic-loadtest:${VERSION}" --platform 'linux/amd64' .
+docker build --tag "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-elastic-loadtest:${VERSION}-heartbeat" --platform 'linux/amd64' --build-arg MODE_HEARTBEAT=1 .
+docker build --tag "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-elastic-loadtest:${VERSION}-webops-heartbeat" --build-arg MODE_HEARTBEAT=1 --build-arg IS_WEBOPS_ENV=1 .
 ```
 
-### No default build but additional build arguments supplied
-
-**Note:** Even though no default build is supplied, you will always get a vanilla build. This is by design
+### Excluding the default build
 
 #### Input (.cruft.json)
 ```json
 {
-  "template": "https://github.com/hmrc/telemetry-docker-resources",
-  "context": {
-    "cookiecutter": {
-      "docker_build_info_additional": {
-        "-heartbeat": {
-          "build_args": [
-            "MODE_HEARTBEAT=1"
-          ]
-        },
-        "-webops-heartbeat": {
-          "build_args": [
-            "MODE_HEARTBEAT=1",
-            "IS_WEBOPS_ENV=1"
-          ]
-        }
-      },
-      "docker_build_info_default": {}
-    }
+  "cookiecutter": {
+    "additional_tool_versions": {},
+    "aws_account_id": "634456480543",
+    "aws_region": "eu-west-2",
+    "custom_makefile_name": "",
+    "docker_build_options_additional": {
+      "-heartbeat": "--platform 'linux/amd64' --build-arg MODE_HEARTBEAT=1",
+      "-webops-heartbeat": "--build-arg MODE_HEARTBEAT=1 --build-arg IS_WEBOPS_ENV=1"
+    },
+    "docker_image_name": "telemetry-elastic-loadtest",
+    "docker_image_name_formatted": "telemetry-elastic-loadtest",
+    "docker_include_default_build": false,
+    "_template": "https://github.com/hmrc/telemetry-docker-resources"
   }
 }
 ```
 
 #### Output (bin/docker-tools.sh)
 ```shell
-  docker build --tag "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${REPO_NAME}:${VERSION}-" .
-  docker build --tag "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${REPO_NAME}:${VERSION}-heartbeat" --build-arg MODE_HEARTBEAT=1 .
-  docker build --tag "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${REPO_NAME}:${VERSION}-webops-heartbeat" --build-arg MODE_HEARTBEAT=1 --build-arg IS_WEBOPS_ENV=1 .
+docker build --tag "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-elastic-loadtest:${VERSION}-heartbeat" --platform 'linux/amd64' --build-arg MODE_HEARTBEAT=1 .
+docker build --tag "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-elastic-loadtest:${VERSION}-webops-heartbeat" --build-arg MODE_HEARTBEAT=1 --build-arg IS_WEBOPS_ENV=1 .
 ```
-
-### Both default and additional build arguments supplied
-
-#### Input (.cruft.json)
-```json
-{
-  "template": "https://github.com/hmrc/telemetry-docker-resources",
-  "context": {
-    "cookiecutter": {
-      "docker_build_info_additional": {
-        "-heartbeat": {
-          "build_args": [
-            "MODE_HEARTBEAT=1"
-          ],
-          "platform": [
-            "'linux/amd64'"
-          ]
-        },
-        "-webops-heartbeat": {
-          "build_args": [
-            "MODE_HEARTBEAT=1",
-            "IS_WEBOPS_ENV=1"
-          ]
-        }
-      },
-      "docker_build_info_default": {
-        "default": {
-          "platform": [
-            "'linux/amd64'"
-          ]
-        }
-      }
-    }
-  }
-}
-```
-
-#### Output (bin/docker-tools.sh)
-```shell
-  docker build --tag "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${REPO_NAME}:${VERSION}" --platform 'linux/amd64' .
-  docker build --tag "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${REPO_NAME}:${VERSION}-heartbeat" --build-arg MODE_HEARTBEAT=1 --platform 'linux/amd64' .
-  docker build --tag "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${REPO_NAME}:${VERSION}-webops-heartbeat" --build-arg MODE_HEARTBEAT=1 --build-arg IS_WEBOPS_ENV=1 .
-```
-
 
 ## References
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,10 +1,12 @@
 {
   "additional_tool_versions": {},
+  "aws_account_id": "634456480543",
   "aws_region": "eu-west-2",
   "custom_makefile_name": "",
-  "docker_build_info_additional": {},
-  "docker_build_info_default": {},
-  "docker_name": null,
-  "docker_name_formatted": "{{ cookiecutter.docker_name|lower|replace(' ', '-') }}",
-  "internal_base_account_id": "634456480543"
+  "docker_build_options_additional": {},
+  "docker_build_options_default": null,
+  "docker_image_name": null,
+  "docker_image_name_formatted": "{{ cookiecutter.docker_name|lower|replace(' ', '-')|replace('_', '-') }}",
+  "docker_include_default_build": true,
+  "repository_name": null
 }

--- a/{{cookiecutter.docker_name_formatted}}/Makefile
+++ b/{{cookiecutter.docker_name_formatted}}/Makefile
@@ -7,9 +7,6 @@ PYTHON_OK := $(shell type -P python)
 PYTHON_REQUIRED := $(shell cat .python-version)
 PYTHON_VERSION ?= $(shell python -V | cut -d' ' -f2)
 
-DOCKER_NAME := {{ cookiecutter.docker_name_formatted }}
-TELEMETRY_INTERNAL_BASE_ACCOUNT_ID := {{ cookiecutter.internal_base_account_id }}
-
 help: ## The help text you're reading
 	@grep --no-filename -E '^[a-zA-Z1-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help

--- a/{{cookiecutter.docker_name_formatted}}/bin/docker-tools.sh
+++ b/{{cookiecutter.docker_name_formatted}}/bin/docker-tools.sh
@@ -9,109 +9,67 @@ set -o nounset
 #####################################################################
 ## Beginning of the configurations ##################################
 
-ACCOUNT_ID="{{ cookiecutter.internal_base_account_id }}"
-AWS_REGION="{{ cookiecutter.aws_region }}"
 BASE_LOCATION="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PATH_BUILD="${BASE_LOCATION}/build"
-PROJECT_FULL_NAME="{{ cookiecutter.docker_name_formatted }}"
-REPO_NAME="{{ cookiecutter.docker_name_formatted }}"
+IMAGE_NAME="{{ cookiecutter.docker_image_name_formatted }}"
 
 ## End of the configurations ########################################
 #####################################################################
 
 debug_env(){
   echo BASE_LOCATION="${BASE_LOCATION}"
-  echo PROJECT_FULL_NAME="${PROJECT_FULL_NAME}"
-  echo PATH_BUILD="${PATH_BUILD}"
-}
-
-open_shell() {
-    print_begins
-
-    poetry export --without-hashes --format requirements.txt --with dev --output "requirements-tests.txt"
-    docker run -it \
-               --rm \
-               --volume "${BASE_LOCATION}":/data \
-               --workdir /data \
-               --env REQUIREMENTS_FILE="requirements-tests.txt" \
-               --env VENV_NAME="venv" \
-               python:$(cat "${BASE_LOCATION}/.python-version")-slim-buster /data/bin/entrypoint.sh /bin/bash
-
-    print_completed
+  echo IMAGE_NAME="${IMAGE_NAME}"
 }
 
 # Creates a release tag in the repository
 cut_release() {
   print_begins
-
   poetry run cut-release
-
   print_completed
 }
 
 # Build the Docker image
 package() {
   print_begins
-
   export_version
 
   echo Building the images
 
-{% if cookiecutter.docker_build_info_default is defined and cookiecutter.docker_build_info_default|length %}
-  {%- for key, value in cookiecutter.docker_build_info_default|dictsort %}
-  docker build --tag "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${REPO_NAME}:${VERSION}"
-    {%- if value.build_args is defined and value.build_args|length %}
-      {%- for build_arg in value.build_args%} --build-arg {{build_arg|safe}} {%- endfor %}
-    {%- endif %}
-    {%- if value.platform is defined and value.platform|length %}
-      {%- for platform in value.platform%} --platform {{platform|safe}} {%- endfor %}
-    {%- endif %} .
-  {%- endfor %}
-{% else %}
-  docker build --tag "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${REPO_NAME}:${VERSION}" .
-{% endif %}
-
-{% if cookiecutter.docker_build_info_additional is defined and cookiecutter.docker_build_info_additional|length %}
-  {%- for key, value in cookiecutter.docker_build_info_additional|dictsort %}
-  docker build --tag "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${REPO_NAME}:${VERSION}{{key|safe}}"
-    {%- if value.build_args is defined and value.build_args|length %}
-      {%- for build_arg in value.build_args%} --build-arg {{build_arg|safe}} {%- endfor %}
-    {%- endif %}
-    {%- if value.platform is defined and value.platform|length %}
-      {%- for platform in value.platform%} --platform {{platform|safe}} {%- endfor %}
-    {%- endif %} .
-  {%- endfor %}
-{% endif %}
-
+{%- if cookiecutter.docker_include_default_build is sameas true %}
+  {%- if cookiecutter.docker_build_options_default is defined and cookiecutter.docker_build_options_default|length %}
+  docker build --tag "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}" {{cookiecutter.docker_build_options_default|safe}} .
+  {%- else %}
+  docker build --tag "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}" .
+  {%- endif %}
+{%- endif %}
+{%- for key, value in cookiecutter.docker_build_options_additional|dictsort %}
+  docker build --tag "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}{{key|safe}}" {{value|safe}} .
+{%- endfor %}
   print_completed
 }
 
 # Bump the function's version when appropriate
 prepare_release() {
   print_begins
-
   poetry run prepare-release
   export_version
-
   print_completed
 }
 
 publish_to_ecr() {
   print_begins
-
   export_version
 
   echo Authenticating with ECR
-  aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+  aws ecr get-login-password --region "{{cookiecutter.aws_region}}" | docker login --username AWS --password-stdin "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com"
+
   echo Pushing the images
 
-  docker push "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${REPO_NAME}:${VERSION}"
-{% if cookiecutter.docker_build_info_additional is defined and cookiecutter.docker_build_info_additional|length %}
-  {%- for key, value in cookiecutter.docker_build_info_additional|dictsort %}
-  docker push "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${REPO_NAME}:${VERSION}{{key|safe}}"
-  {%- endfor %}
-{% endif %}
-
+{%- if cookiecutter.docker_include_default_build is sameas true %}
+  docker push "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}"
+{%- endif %}
+{%- for key, value in cookiecutter.docker_build_options_additional|dictsort %}
+  docker push "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}{{key|safe}}"
+{%- endfor %}
   print_completed
 }
 
@@ -152,8 +110,7 @@ print_completed() {
 
 print_configs() {
   echo -e "BASE_LOCATION:\t\t\t${BASE_LOCATION}"
-  echo -e "PATH_BUILD:\t\t\t${PATH_BUILD}"
-  echo -e "PROJECT_FULL_NAME:\t\t${PROJECT_FULL_NAME}"
+  echo -e "IMAGE_NAME:\t\t${IMAGE_NAME}"
 }
 
 ## End of the helper methods ########################################
@@ -165,11 +122,8 @@ main() {
   # Validate command arguments
   [ "$#" -ne 1 ] && help && exit 1
   function="$1"
-  functions="help cut_release debug_env open_shell package prepare_release print_configs publish_to_ecr"
+  functions="help cut_release debug_env package prepare_release print_configs publish_to_ecr"
   [[ $functions =~ (^|[[:space:]])"$function"($|[[:space:]]) ]] || (echo -e "\n\"$function\" is not a valid command. Try \"$0 help\" for more details" && exit 2)
-
-  # Ensure build folder is available
-  mkdir -p "${PATH_BUILD}"
 
   $function
 }


### PR DESCRIPTION
What did we do?
--

1. Refactored how the build options are specified to make it much easier to maintain and read

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-1866
http://jinja.quantprogramming.com/

Evidence of work
--

1. Input YAML
```
cookiecutter:
  additional_tool_versions: {}
  aws_account_id: '634456480543'
  aws_region: eu-west-2
  custom_makefile_name: ''
  docker_build_options_additional:
    "-heartbeat": "--platform 'linux/amd64' --build-arg MODE_HEARTBEAT=1"
    "-webops-heartbeat": "--build-arg MODE_HEARTBEAT=1 --build-arg IS_WEBOPS_ENV=1"
  docker_image_name: telemetry-elastic-loadtest
  docker_image_name_formatted: telemetry-elastic-loadtest
  docker_build_options_default: "--platform 'linux/amd64'"
  docker_include_default_build: true
  _template: https://github.com/hmrc/telemetry-docker-resources
```
2. Input Template
```
#!/usr/bin/env bash

# A helper tool to assist us maintaining docker functions
# Intention here is to keep this files and all its functions reusable for all Telemetry repositories

set -o errexit
set -o nounset

#####################################################################
## Beginning of the configurations ##################################

BASE_LOCATION="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
IMAGE_NAME="{{ cookiecutter.docker_image_name_formatted }}"

## End of the configurations ########################################
#####################################################################

debug_env(){
  echo BASE_LOCATION="${BASE_LOCATION}"
  echo IMAGE_NAME="${IMAGE_NAME}"
}

# Creates a release tag in the repository
cut_release() {
  print_begins
  poetry run cut-release
  print_completed
}

# Build the Docker image
package() {
  print_begins
  export_version

  echo Building the images

{%- if cookiecutter.docker_include_default_build is sameas true %}
  {%- if cookiecutter.docker_build_options_default is defined and cookiecutter.docker_build_options_default|length %}
  docker build --tag "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}" {{cookiecutter.docker_build_options_default|safe}} .
  {%- else %}
  docker build --tag "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}" .
  {%- endif %}
{%- endif %}
{%- for key, value in cookiecutter.docker_build_options_additional|dictsort %}
  docker build --tag "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}{{key|safe}}" {{value|safe}} .
{%- endfor %}
  print_completed
}

# Bump the function's version when appropriate
prepare_release() {
  print_begins
  poetry run prepare-release
  export_version
  print_completed
}

publish_to_ecr() {
  print_begins
  export_version

  echo Authenticating with ECR
  aws ecr get-login-password --region "{{cookiecutter.aws_region}}" | docker login --username AWS --password-stdin "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com"

  echo Pushing the images

{%- if cookiecutter.docker_include_default_build is sameas true %}
  docker push "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}"
{%- endif %}
{%- for key, value in cookiecutter.docker_build_options_additional|dictsort %}
  docker push "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}{{key|safe}}"
{%- endfor %}
  print_completed
}

#####################################################################
## Beginning of the helper methods ##################################

export_version() {

  if [ ! -f ".version" ]; then
    echo ".version file not found! Have you run prepare_release command?"
    exit 1
  fi

  VERSION=$(cat .version)
  export VERSION=${VERSION}
}

help() {
  echo "$0 Provides set of commands to assist you with day-to-day tasks when working in this project"
  echo
  echo "Available commands:"
  echo -e " - prepare_release\t\t Bump the function's version when appropriate"
  echo -e " - cut_release\t\t Creates a release tag in the repository"
  echo -e " - package\t\t\t Build the Docker image"
  echo -e " - publish_to_ecr\t Upload Docker image to internal-base ECR"
  echo
}

print_begins() {
  echo -e "\n-------------------------------------------------"
  echo -e ">>> ${FUNCNAME[1]} Begins\n"
}

print_completed() {
  echo -e "\n### ${FUNCNAME[1]} Completed!"
  echo -e "-------------------------------------------------"
}

print_configs() {
  echo -e "BASE_LOCATION:\t\t\t${BASE_LOCATION}"
  echo -e "IMAGE_NAME:\t\t${IMAGE_NAME}"
}

## End of the helper methods ########################################
#####################################################################

#####################################################################
## Beginning of the Entry point #####################################
main() {
  # Validate command arguments
  [ "$#" -ne 1 ] && help && exit 1
  function="$1"
  functions="help cut_release debug_env package prepare_release print_configs publish_to_ecr"
  [[ $functions =~ (^|[[:space:]])"$function"($|[[:space:]]) ]] || (echo -e "\n\"$function\" is not a valid command. Try \"$0 help\" for more details" && exit 2)

  $function
}

main "$@"
## End of the Entry point ###########################################
#####################################################################

```
3. Output Bash
```
#!/usr/bin/env bash

# A helper tool to assist us maintaining docker functions
# Intention here is to keep this files and all its functions reusable for all Telemetry repositories

set -o errexit
set -o nounset

#####################################################################
## Beginning of the configurations ##################################

BASE_LOCATION="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
IMAGE_NAME="telemetry-elastic-loadtest"

## End of the configurations ########################################
#####################################################################

debug_env(){
  echo BASE_LOCATION="${BASE_LOCATION}"
  echo IMAGE_NAME="${IMAGE_NAME}"
}

# Creates a release tag in the repository
cut_release() {
  print_begins
  poetry run cut-release
  print_completed
}

# Build the Docker image
package() {
  print_begins
  export_version

  echo Building the images
  docker build --tag "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-elastic-loadtest:${VERSION}" --platform 'linux/amd64' .
  docker build --tag "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-elastic-loadtest:${VERSION}-heartbeat" --platform 'linux/amd64' --build-arg MODE_HEARTBEAT=1 .
  docker build --tag "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-elastic-loadtest:${VERSION}-webops-heartbeat" --build-arg MODE_HEARTBEAT=1 --build-arg IS_WEBOPS_ENV=1 .
  print_completed
}

# Bump the function's version when appropriate
prepare_release() {
  print_begins
  poetry run prepare-release
  export_version
  print_completed
}

publish_to_ecr() {
  print_begins
  export_version

  echo Authenticating with ECR
  aws ecr get-login-password --region "eu-west-2" | docker login --username AWS --password-stdin "634456480543.dkr.ecr.eu-west-2.amazonaws.com"

  echo Pushing the images
  docker push "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-elastic-loadtest:${VERSION}"
  docker push "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-elastic-loadtest:${VERSION}-heartbeat"
  docker push "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-elastic-loadtest:${VERSION}-webops-heartbeat"
  print_completed
}

#####################################################################
## Beginning of the helper methods ##################################

export_version() {

  if [ ! -f ".version" ]; then
    echo ".version file not found! Have you run prepare_release command?"
    exit 1
  fi

  VERSION=$(cat .version)
  export VERSION=${VERSION}
}

help() {
  echo "$0 Provides set of commands to assist you with day-to-day tasks when working in this project"
  echo
  echo "Available commands:"
  echo -e " - prepare_release\t\t Bump the function's version when appropriate"
  echo -e " - cut_release\t\t Creates a release tag in the repository"
  echo -e " - package\t\t\t Build the Docker image"
  echo -e " - publish_to_ecr\t Upload Docker image to internal-base ECR"
  echo
}

print_begins() {
  echo -e "\n-------------------------------------------------"
  echo -e ">>> ${FUNCNAME[1]} Begins\n"
}

print_completed() {
  echo -e "\n### ${FUNCNAME[1]} Completed!"
  echo -e "-------------------------------------------------"
}

print_configs() {
  echo -e "BASE_LOCATION:\t\t\t${BASE_LOCATION}"
  echo -e "IMAGE_NAME:\t\t${IMAGE_NAME}"
}

## End of the helper methods ########################################
#####################################################################

#####################################################################
## Beginning of the Entry point #####################################
main() {
  # Validate command arguments
  [ "$#" -ne 1 ] && help && exit 1
  function="$1"
  functions="help cut_release debug_env package prepare_release print_configs publish_to_ecr"
  [[ $functions =~ (^|[[:space:]])"$function"($|[[:space:]]) ]] || (echo -e "\n\"$function\" is not a valid command. Try \"$0 help\" for more details" && exit 2)

  $function
}

main "$@"
## End of the Entry point ###########################################
#####################################################################
```

Next Steps
--

1. Update all consuming docker repos to use the new version

Risks
--

1. None

Collaboration
--

Co-authored-by: Willem Veerman <6502426+willemveerman@users.noreply.github.com>
