### PR TITLE
TEL-4085 Update Cookiecutter attributes and documentation

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,11 +1,12 @@
 {
-  "additional_tool_versions": {},
+  "additional_tool_versions": null,
   "aws_account_id": "634456480543",
   "aws_region": "eu-west-2",
   "custom_makefile_name": "",
-  "docker_build_options_additional": {},
+  "docker_build_options_additional": null,
   "docker_build_options_default": "",
   "docker_image_name": null,
   "docker_image_name_formatted": "{{ cookiecutter.docker_image_name|lower|replace(' ', '-')|replace('_', '-') }}",
-  "docker_include_default_build": false
+  "docker_include_default_build": false,
+  "repository_name": null
 }

--- a/docs/cookiecutter-attributes.md
+++ b/docs/cookiecutter-attributes.md
@@ -4,19 +4,25 @@ This document provides information about this boilerplate's required and optiona
 
 ## Required attributes
 
-| Attribute                       | Type    | Example                                                             |
-|---------------------------------|---------|---------------------------------------------------------------------|
-| **docker_image_name**           | string  | "project-name"                                                      | 
-| **docker_image_name_formatted** | string  | this will be auto-populated based on the provided docker_image_name |
+| Attribute                           | Type     | Example                                                             |
+|-------------------------------------|----------|---------------------------------------------------------------------|
+| **additional_tool_versions**        | json     | {} or {"golang": "1.21.0"}                                          |
+| **docker_build_options_additional** | json     | {} or {"tag": "--build-arg foo=bar"}                              |
+| **docker_image_name**               | string   | "project-name"                                                      | 
+| **docker_image_name_formatted**     | string   | this will be auto-populated based on the provided docker_image_name |
 
 ## Optional attributes
 
-| Attribute                           | Type     | Example                                         |
-|-------------------------------------|----------|-------------------------------------------------|
-| **additional_tool_versions**        | json     | {"golang": "1.21."}                             |
-| **aws_account_id**                  | string   | "634456480543"                                  |
-| **aws_region**                      | string   | "eu-west-2"                                     | 
-| **custom_makefile_name**            | string   | "eu-west-2"                                     |
-| **docker_build_options_additional** | json     | {"--build-arg foo=bar", "--build-arg foo=bar"}  |
-| **docker_build_options_default**    | string   | "--build-arg foo=bar"                           |
-| **docker_include_default_build**    | boolean  | y                                               |
+| Attribute                           | Type     | default        | Example                     |
+|-------------------------------------|----------|----------------|-----------------------------|
+| **aws_account_id**                  | string   | "634456480543" | "112233445566"              |
+| **aws_region**                      | string   | "eu-west-2"    | "eu-west-1"                 | 
+| **custom_makefile_name**            | string   | ""             | "ExtraMakefile"             |        
+| **docker_build_options_default**    | string   | ""             | "--platform 'linux/amd64'"  |
+| **docker_include_default_build**    | boolean  | n (for false)  | y (for ture)                | 
+
+## Please note:
+It is impossible to use empty dictionary as default value for Cookiecutter's attribute. i.e. `additional_tool_versions`
+Doing so would not allow the child repository's .cruft.json file to overwrite its value.
+Therefore, we had to keep them as required attributes by setting the default value to null. 
+This means child repositories must at least pass an empty dictionary during initiation. i.e. `{}`  

--- a/{{cookiecutter.docker_image_name_formatted}}/.tool-versions
+++ b/{{cookiecutter.docker_image_name_formatted}}/.tool-versions
@@ -1,6 +1,6 @@
 poetry 1.6.1
 python 3.10.8
-{%- if cookiecutter.additional_tool_versions is defined and cookiecutter.additional_tool_versions|length %}
+{%- if cookiecutter.additional_tool_versions is defined and cookiecutter.additional_tool_versions is mapping and cookiecutter.additional_tool_versions|length %}
   {%- for key, value in cookiecutter.additional_tool_versions|dictsort %}
 {{key|safe}} {{value|safe}}
 {%- endfor %}

--- a/{{cookiecutter.docker_image_name_formatted}}/bin/docker-tools.sh
+++ b/{{cookiecutter.docker_image_name_formatted}}/bin/docker-tools.sh
@@ -41,7 +41,7 @@ package() {
 
   echo Building the images
 
-{%- if cookiecutter.docker_include_default_build|lower == "true" %}
+{%- if cookiecutter.docker_include_default_build is sameas true %}
   {%- if cookiecutter.docker_build_options_default is defined and cookiecutter.docker_build_options_default|length %}
   docker build --tag "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}" {{cookiecutter.docker_build_options_default|safe}} .
   {%- else %}
@@ -71,7 +71,7 @@ publish_to_ecr() {
 
   echo Pushing the images
 
-{%- if cookiecutter.docker_include_default_build|lower == "true" %}
+{%- if cookiecutter.docker_include_default_build is sameas true %}
   docker push "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}"
 {%- endif %}
 {%- for key, value in cookiecutter.docker_build_options_additional|dictsort %}


### PR DESCRIPTION
What did we do?
--

1. Update Cookiecutter attributes as it won't allow overwriting default dictionaries.
2. Update documents to make it clear why we have to keep the null values which makes initiating new repositories complicated.

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4085

Evidence of work
--

1.

Next Steps
--

1.

Risks
--

1.

Collaboration
--
Co-authored-by: Rob White <Crumplepang@users.noreply.github.com>
