### PR TITLE
TEL-4126 Remove the hardcoded local context

### DIFF
--- a/docs/cookiecutter-attributes.md
+++ b/docs/cookiecutter-attributes.md
@@ -7,7 +7,7 @@ This document provides information about this boilerplate's required and optiona
 | Attribute                           | Type     | Example                                                             |
 |-------------------------------------|----------|---------------------------------------------------------------------|
 | **additional_tool_versions**        | json     | {} or {"golang": "1.21.0"}                                          |
-| **docker_build_options_additional** | json     | {} or {"tag": "--build-arg foo=bar"}                              |
+| **docker_build_options_additional** | json     | {} or {"_some_tag": "--build-arg foo=bar ."}                        |
 | **docker_image_name**               | string   | "project-name"                                                      | 
 | **docker_image_name_formatted**     | string   | this will be auto-populated based on the provided docker_image_name |
 

--- a/{{cookiecutter.docker_image_name_formatted}}/bin/docker-tools.sh
+++ b/{{cookiecutter.docker_image_name_formatted}}/bin/docker-tools.sh
@@ -49,7 +49,7 @@ package() {
   {%- endif %}
 {%- endif %}
 {%- for key, value in cookiecutter.docker_build_options_additional|dictsort %}
-  docker build --tag "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}{{key|safe}}" {{value|safe}} .
+  docker build --tag "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}{{key|safe}}" {{value|safe}}
 {%- endfor %}
   print_completed
 }


### PR DESCRIPTION
What did we do?
--

1. Make it possible to include additional builds which most likely have their own context.
i.e. [In here](https://github.com/hmrc/telemetry-metrics-healthcheck/pull/26/files#diff-7b1438cc5a871699533a558b896508c905226be2ee0f8aab1ebd6d2795e79f5eR17) we would like to have `./goss` instead of `.` and expect to render a command like 
```
docker build 
   --tag "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-metrics-healthcheck:${VERSION}_goss" 
   --file ./goss/Dockerfile ./goss
``` 
But the hard-coded local context as it is makes it impossible and breaks the script
```
docker build 
   --tag "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-metrics-healthcheck:${VERSION}_goss" 
   --file ./goss/Dockerfile ./goss .
``` 

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4126

Evidence of work
--

1.

Next Steps
--

1. Make sure other places this template has been used are including the local context location, i.e. `.`
1.2. https://github.com/hmrc/telemetry-build-container/blob/main/.cruft.json#L22
1.3. https://github.com/hmrc/telemetry-status-checks/blob/main/.cruft.json#L17
2. Update their Crufts

Risks
--

1.

Collaboration
--

Co-authored-by:
