### PR TITLE
TEL-4189 Updates security-git-hooks pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         name: Fix missing end-of-file line returns
         exclude: repository.yaml|tests/unit/test-data/
   - repo: https://github.com/hmrc/security-git-hooks
-    rev: release/1.9.0
+    rev: release/1.10.0
     hooks:
       - id: secrets_filecontent
         name: Checking staged files for sensitive content

--- a/docs/cookiecutter-attributes.md
+++ b/docs/cookiecutter-attributes.md
@@ -1,6 +1,6 @@
 # Cookiecutter
 
-This document provides information about this boilerplate's required and optional attributes  
+This document provides information about this boilerplate's required and optional attributes
 
 ## Required attributes
 
@@ -8,7 +8,7 @@ This document provides information about this boilerplate's required and optiona
 |-------------------------------------|----------|---------------------------------------------------------------------|
 | **additional_tool_versions**        | json     | {} or {"golang": "1.21.0"}                                          |
 | **docker_build_options_additional** | json     | {} or {"_some_tag": "--build-arg foo=bar ."}                        |
-| **docker_image_name**               | string   | "project-name"                                                      | 
+| **docker_image_name**               | string   | "project-name"                                                      |
 | **docker_image_name_formatted**     | string   | this will be auto-populated based on the provided docker_image_name |
 
 ## Optional attributes
@@ -16,13 +16,13 @@ This document provides information about this boilerplate's required and optiona
 | Attribute                           | Type     | default        | Example                     |
 |-------------------------------------|----------|----------------|-----------------------------|
 | **aws_account_id**                  | string   | "634456480543" | "112233445566"              |
-| **aws_region**                      | string   | "eu-west-2"    | "eu-west-1"                 | 
-| **custom_makefile_name**            | string   | ""             | "ExtraMakefile"             |        
+| **aws_region**                      | string   | "eu-west-2"    | "eu-west-1"                 |
+| **custom_makefile_name**            | string   | ""             | "ExtraMakefile"             |
 | **docker_build_options_default**    | string   | ""             | "--platform 'linux/amd64'"  |
-| **docker_include_default_build**    | boolean  | n (for false)  | y (for ture)                | 
+| **docker_include_default_build**    | boolean  | n (for false)  | y (for ture)                |
 
 ## Please note:
 It is impossible to use empty dictionary as default value for Cookiecutter's attribute. i.e. `additional_tool_versions`
 Doing so would not allow the child repository's .cruft.json file to overwrite its value.
-Therefore, we had to keep them as required attributes by setting the default value to null. 
-This means child repositories must at least pass an empty dictionary during initiation. i.e. `{}`  
+Therefore, we had to keep them as required attributes by setting the default value to null.
+This means child repositories must at least pass an empty dictionary during initiation. i.e. `{}`

--- a/{{cookiecutter.docker_image_name_formatted}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.docker_image_name_formatted}}/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         name: Fix missing end-of-file line returns
         exclude: repository.yaml|tests/unit/test-data/
   - repo: https://github.com/hmrc/security-git-hooks
-    rev: release/1.9.0
+    rev: release/1.10.0
     hooks:
       - id: secrets_filecontent
         name: Checking staged files for sensitive content


### PR DESCRIPTION
What we have done
--

Updated the hook to a version that pulls in setuptools under python 3.12, to fix "No module named 'pkg_resources" errors.

References
--

1. Fix described here https://github.com/hmrc/security-git-hooks/pull/24
2. https://jira.tools.tax.service.gov.uk/browse/TEL-4189

Evidence of work
--

1. Run 'pre-commit  run --all-files --verbose secrets_filecontent'
2. **Assert that** it passes

Collaborators
--

Co-authored by: Stephen Palfreyman <18111914+sjpalf@users.noreply.github.com>
