### PR TITLE
TEL-4189 use artifactory for python dependencies

### DIFF
--- a/{{cookiecutter.docker_image_name_formatted}}/Makefile
+++ b/{{cookiecutter.docker_image_name_formatted}}/Makefile
@@ -65,7 +65,7 @@ publish_to_ecr: ## Push the Docker image to the internal-base ECR repo
 .PHONY: publish_to_ecr
 
 setup: check_poetry ## Setup virtualenv & dependencies using poetry and set-up the git hook scripts
-	@export POETRY_VIRTUALENVS_IN_PROJECT=$(POETRY_VIRTUALENVS_IN_PROJECT) && poetry run pip install --upgrade pip
+	@export POETRY_VIRTUALENVS_IN_PROJECT=$(POETRY_VIRTUALENVS_IN_PROJECT) && poetry run pip install --index-url https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple --upgrade pip
 	@poetry config --list
 	@poetry install --no-root
 	@poetry run pre-commit install


### PR DESCRIPTION
What did we do?
--

1. Updated pip install to use artifactory

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4189

Collaboration
--

Co-authored-by: Gavin Davies <gavD@users.noreply.github.com>
