### PR TITLE
TEL-4444 Adds latest tag on main build

### DIFF
--- a/{{cookiecutter.docker_image_name_formatted}}/bin/docker-tools.sh
+++ b/{{cookiecutter.docker_image_name_formatted}}/bin/docker-tools.sh
@@ -67,6 +67,7 @@ publish_to_ecr() {
 
 {%- if cookiecutter.docker_include_default_build is sameas true %}
   docker push "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}"
+  docker push "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:latest"
 {%- endif %}
 {%- for key, value in cookiecutter.docker_build_options_additional|dictsort %}
   docker push "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}{{key|safe}}"


### PR DESCRIPTION
What did we do?
--

1. Added an additional tag to any build `latest` which is used by the deployment mechanism

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4444

Evidence of work
--

Ran `ecr-push-telemetry-carbon-relay-ng` with branch build override of `TEL-4444-d`

Didn't work because you need a `git tag` for the release

To actually test this, given how Cruft works and the fact I need the main buildspec.yml to run, I need to actually merge this, update `telemetry-carbon-relay-ng` (which is already 7 Cruft versions behind), and then merge a change to `telemetry-carbon-relay-ng`.

So the strategy is to **merge, test, then back out/fix forward if no good**

Next Steps
--

1. See https://github.com/hmrc/telemetry-terraform/pull/3638

Risks
--

1. If you were to `verify_publish_release` from a branch, I suspect that it would add the `latest` tag
    a. If you look at our buildspec.yml files, only the main branch should run `verify_publish_release`
2. See EoW for difficulties testing

Collaboration
--

Co-authored by: Alex Tasioulis @alextcap <174622239+alextcap@users.noreply.github.com>
Co-authored by: Stephen Palfreyman @sjpalf  <18111914+sjpalf@users.noreply.github.com>
