### PR TITLE
TEL-4444 Applies tag 'latest' at build time

### DIFF
--- a/{{cookiecutter.docker_image_name_formatted}}/bin/docker-tools.sh
+++ b/{{cookiecutter.docker_image_name_formatted}}/bin/docker-tools.sh
@@ -37,9 +37,9 @@ package() {
   echo Building the images
 {%- if cookiecutter.docker_include_default_build is sameas true %}
   {%- if cookiecutter.docker_build_options_default is defined and cookiecutter.docker_build_options_default|length %}
-  docker build --tag "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}" {{cookiecutter.docker_build_options_default|safe}} .
+  docker build --tag "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}" --tag "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:latest" {{cookiecutter.docker_build_options_default|safe}} .
   {%- else %}
-  docker build --tag "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}" .
+  docker build --tag "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:${VERSION}" --tag "{{cookiecutter.aws_account_id}}.dkr.ecr.{{cookiecutter.aws_region}}.amazonaws.com/{{cookiecutter.docker_image_name_formatted}}:" .
   {%- endif %}
 {%- endif %}
 {%- for key, value in cookiecutter.docker_build_options_additional|dictsort %}


### PR DESCRIPTION
What did we do?
--

Build failed with:

```
0.3.0: digest: sha256:7f08616c447d41392a8da3c991624d8a1413c0e2fc03f81ce0e28bd737d37788 size: 1573
--
392 | The push refers to repository [634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-carbon-relay-ng]
393 | time="2024-11-15T14:52:08.602186123Z" level=info msg="Attempting next endpoint for push after error: tag does not exist: 634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-carbon-relay-ng:latest"
394 | tag does not exist: 634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-carbon-relay-ng:latest
395 | make: *** [Makefile:54: publish_to_ecr] Error 1
396 |  
397 | [Container] 2024/11/15 14:52:08.604213 Command did not exit successfully make verify_publish_release exit status 2

```

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4444

Evidence of work
--

None but the docs suggest that the tag needs to be created before pushing

Next Steps
--

1. Update telemetry-carbon-relay-ng to cruft update
2. Push
3. Observe

Risks
--

This is blind firing

Collaboration
--

Co-authored by: Alex Tasioulis @alextcap <174622239+alextcap@users.noreply.github.com>
Co-authored by: Stephen Palfreyman @sjpalf  <18111914+sjpalf@users.noreply.github.com>
